### PR TITLE
Handle files containing "export default {" stuff

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,12 @@ function getClasses(content) {
     from = content.indexOf('exports.locals = {');
   }
 
+  // FIX START: fix for empty classes for gatsby
+  if (from === -1) {
+    from = content.indexOf('export default {')
+  }
+  // FIX END
+
   if (~from) {
     content = content.slice(from);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-css-modules-loader",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "webpack loader to generate typings for css modules",
   "peerDependencies": {
     "css-loader": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"


### PR DESCRIPTION
Handle files containing "export default {" stuff

it's used in gatsby